### PR TITLE
Allow to override the domain where response is put

### DIFF
--- a/acme_dns_tiny.py
+++ b/acme_dns_tiny.py
@@ -181,7 +181,7 @@ def get_crt(config, log=LOGGER):
         token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge["token"])
         keyauthorization = "{0}.{1}".format(token, thumbprint)
         keydigest64 = _b64(hashlib.sha256(keyauthorization.encode("utf8")).digest())
-        dnsrr_domain = "_acme-challenge.{0}.".format(domain)
+        dnsrr_domain = config["DNS"]["ChallengeDomain"].format(domain)
         dnsrr_set = dns.rrset.from_text(dnsrr_domain, 300, "IN", "TXT",  '"{0}"'.format(keydigest64))
         try:
             _update_dns(dnsrr_set, "add")
@@ -289,7 +289,7 @@ See example.ini file to configure correctly this script.
     config = ConfigParser()
     config.read_dict({"acmednstiny": {"ACMEDirectory": "https://acme-staging-v02.api.letsencrypt.org/directory",
                                       "CheckChallengeDelay": 3},
-                      "DNS": {"Port": "53"}})
+                      "DNS": {"ChallengeDomain": "_acme-challenge.{0}.", "Port": "53"}})
     config.read(args.configfile)
 
     if (set(["accountkeyfile", "csrfile", "acmedirectory", "checkchallengedelay"]) - set(config.options("acmednstiny"))

--- a/example.ini
+++ b/example.ini
@@ -38,3 +38,9 @@ Zone = dnszone
 Host = dnsserver
 # Optional port to connect on DNS server (default: 53)
 Port = 53
+# Optional format string where to put the response RRs. {0} is where
+# acme-dns-tiny fills in the requested domain.
+# This might be necessary if you cannot alter the necessary domains records
+# yourself, but have CNAMEs pointing to another record you *can* change.
+# Default: "_acme-challenge.{0}."
+ChallengeDomain = _acme-challenge.{0}.


### PR DESCRIPTION
In my setup we do not allow individual servers to write to the main zone, so we have all `_acme-challenge.$domain` entries as CNAMEs pointing to a different zone, one for each server. Thus when our servers request certificates, they have to put the response to the challenge into a different RR in a different Zone.

This change simply allows a custom format string to be set in the configuration file, instead of the default `_acme-challenge.{0}.`