### PR TITLE
logger: add forgotten string format

### DIFF
--- a/acme_dns_tiny.py
+++ b/acme_dns_tiny.py
@@ -257,14 +257,14 @@ def get_crt(config, log=LOGGER):
         else:
             raise ValueError("Finalizing order {0} got errors: {1}".format(
                 domain, order))
-    
+
     joseheaders['Accept'] = config["acmednstiny"].get("CertificateFormat", 'application/pem-certificate-chain')
     http_response, result = _send_signed_request(order["certificate"], "")
     if http_response.status_code != 200:
         raise ValueError("Finalizing order {0} got errors: {1}".format(http_response.status_code, result))
 
     if 'link' in http_response.headers:
-        log.info("  - Certificate links given by server: {0}", http_response.headers['link'])
+        log.info("  - Certificate links given by server: {0}".format(http_response.headers['link']))
 
     log.info("Certificate signed and chain received: {0}".format(order["certificate"]))
     return http_response.text


### PR DESCRIPTION
Python 3.7 complains that not all arguments converted during string formatting.

```python
import logging

LOGGER = logging.getLogger('acme_dns_tiny')
LOGGER.addHandler(logging.StreamHandler())
LOGGER.setLevel(logging.INFO)

a = { 'link': 'test' }

LOGGER.info("  - Certificate links given by server: {0}", a['link'])
```

```shell
$ python3.7 --version
Python 3.7.3
$ python3.7 test.py
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.7/logging/__init__.py", line 1034, in emit
    msg = self.format(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 880, in format
    return fmt.format(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 619, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.7/logging/__init__.py", line 380, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "test.py", line 9, in <module>
    LOGGER.info("  - Certificate links given by server: {0}", a['link'])
Message: '  - Certificate links given by server: {0}'
Arguments: ('test',)
```